### PR TITLE
Updated readme file guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <img src="assets/header.png">
 
-Full documentation with user guides for this plugin can be found [here](https://stuart-team.atlassian.net/wiki/spaces/EN/pages/3455550103/WooCommerce+on-demand)
+Full documentation with user guides for this plugin can be found [here](https://community.stuart.engineering/t/stuart-woocommerce-plug-in/1564)
 
 ### Changelog
 


### PR DESCRIPTION
Updated the link to the WooCommerce guide to our community forum page as this is public facing

<!--
Thanks for wanting to fix something on the Stuart WordPress Plugin!
Please fill in the template below.
-->

### Pull Request check-list

Does this PR fix an existing issue?

- [] No, this PR is not related to any existing issue

### Description of change
I have taken the guide from the confluence page and enhanced it for our community forum page.
Our confluence page is not public facing and client's clicking on the reademe file's guide will produce an error.
This has been changed by changing the guide's redirection URL to our community forum page which is public facing.

I<img width="1080" alt="Screenshot 2022-05-13 at 11 43 06 am" src="https://user-images.githubusercontent.com/105438244/168267585-8c2bb7bf-9ffa-49ff-a025-9378b7f75814.png">

